### PR TITLE
Remove unused jersey.verion variable for release/4.3.10

### DIFF
--- a/management-core-resources/pom.xml
+++ b/management-core-resources/pom.xml
@@ -11,10 +11,6 @@
   <name>management-core-resources</name>
   <description>Core library for Terracotta management JAX RS resources</description>
 
-  <properties>
-    <jersey.version>2.31</jersey.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.terracotta</groupId>


### PR DESCRIPTION
* make it clearer that we're reusing the version from thirdparty-bom-4.x now