### PR TITLE
Upgrade jersey from 2.31 to 2.35 for release/4.3.9

### DIFF
--- a/management-core-resources/pom.xml
+++ b/management-core-resources/pom.xml
@@ -12,7 +12,7 @@
   <description>Core library for Terracotta management JAX RS resources</description>
 
   <properties>
-    <jersey.version>2.31</jersey.version>
+    <jersey.version>2.35</jersey.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
 * Includes fix for CVE-2021-28168