### PR TITLE
TAB-9575: REST endpoints now throw 403 (FORBIDDEN) when appropriate.

### DIFF
--- a/management-core/pom.xml
+++ b/management-core/pom.xml
@@ -16,6 +16,21 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <scope>test</scope>

--- a/management-core/src/main/java/org/terracotta/management/security/web/shiro/PermsFilter.java
+++ b/management-core/src/main/java/org/terracotta/management/security/web/shiro/PermsFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.security.web.shiro;
+
+import java.io.IOException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.apache.shiro.web.filter.authz.PermissionsAuthorizationFilter;
+import org.apache.shiro.web.util.WebUtils;
+
+public class PermsFilter extends PermissionsAuthorizationFilter {
+  private static final String MESSAGE = "Access denied.";
+
+  @Override
+  protected boolean onAccessDenied(ServletRequest request, ServletResponse response) throws IOException {
+    if (!response.isCommitted()) {
+      try {
+        WebUtils.toHttp(response).sendError(403, MESSAGE);
+      } catch (ClassCastException cce) {
+        return super.onAccessDenied(request, response);
+      }
+    }
+
+    return false;
+  }
+}

--- a/management-core/src/main/java/org/terracotta/management/security/web/shiro/RestFilter.java
+++ b/management-core/src/main/java/org/terracotta/management/security/web/shiro/RestFilter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.security.web.shiro;
+
+import java.io.IOException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+
+import org.apache.shiro.web.filter.authz.HttpMethodPermissionFilter;
+import org.apache.shiro.web.util.WebUtils;
+
+public class RestFilter extends HttpMethodPermissionFilter {
+  private static final String MESSAGE = "Access denied.";
+
+  @Override
+  protected boolean onAccessDenied(ServletRequest request, ServletResponse response) throws IOException {
+    if (!response.isCommitted()) {
+      try {
+        WebUtils.toHttp(response).sendError(403, MESSAGE);
+      } catch (ClassCastException cce) {
+        return super.onAccessDenied(request, response);
+      }
+    }
+
+    return false;
+  }
+}

--- a/management-core/src/main/java/org/terracotta/management/security/web/shiro/RolesFilter.java
+++ b/management-core/src/main/java/org/terracotta/management/security/web/shiro/RolesFilter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.security.web.shiro;
+
+import java.io.IOException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import org.apache.shiro.web.filter.authz.RolesAuthorizationFilter;
+import org.apache.shiro.web.util.WebUtils;
+
+public class RolesFilter extends RolesAuthorizationFilter {
+  private static final String MESSAGE = "Access denied.";
+
+  @Override
+  protected boolean onAccessDenied(ServletRequest request, ServletResponse response) throws IOException {
+    if (!response.isCommitted()) {
+      try {
+        WebUtils.toHttp(response).sendError(403, MESSAGE);
+      } catch (ClassCastException cce) {
+        return super.onAccessDenied(request, response);
+      }
+    }
+
+    return false;
+  }
+}

--- a/management-core/src/main/java/org/terracotta/management/security/web/shiro/TCRealmSupport.java
+++ b/management-core/src/main/java/org/terracotta/management/security/web/shiro/TCRealmSupport.java
@@ -1,0 +1,12 @@
+package org.terracotta.management.security.web.shiro;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public interface TCRealmSupport {
+  String TERRACOTTA_PERM = "api:read";
+
+  String OPERATOR_PERM = "api:read";
+
+  Collection<String> ADMIN_PERMS = Arrays.asList("api:update", "api:create", "api:delete");
+}

--- a/management-core/src/main/java/org/terracotta/management/security/web/shiro/TCWebIniSecurityManagerFactory.java
+++ b/management-core/src/main/java/org/terracotta/management/security/web/shiro/TCWebIniSecurityManagerFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Terracotta, Inc.
+ * Copyright Super iPaaS Integration LLC, an IBM Company 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terracotta.management.security.web.shiro;
+
+import org.apache.shiro.config.Ini;
+import org.apache.shiro.web.config.WebIniSecurityManagerFactory;
+
+import javax.servlet.Filter;
+import java.util.Map;
+
+/**
+ * This class overrides the default Shiro authorization filters to return 403 (Forbidden) when access is denied.
+ * The Shiro filters return 401 (Unauthorized) for some reason.
+ *
+ * Currently only the "roles" and "rest" filters are used, with "perms" being added for completeness’ sake.
+ */
+public class TCWebIniSecurityManagerFactory extends WebIniSecurityManagerFactory {
+  @Override
+  protected Map<String, ?> createDefaults(Ini ini, Ini.Section mainSection) {
+    @SuppressWarnings("unchecked")
+    Map<String, Filter> defaults = (Map<String, Filter>) super.createDefaults(ini, mainSection);
+    defaults.replace("roles", new RolesFilter());
+    defaults.replace("perms", new PermsFilter());
+    defaults.replace("rest", new RestFilter());
+    return defaults;
+  }
+}


### PR DESCRIPTION
REST endpoints protected from unauthorized usage by Shiro (operator role can only successfully invoke GET)

(cherry picked from commit 524ca7c416ec39739922f98630d32ebebb38c951) (cherry picked from commit 3775d7f93754c8733e1b66dc0a837aac6a88cfb9)